### PR TITLE
More streamlined and informative display

### DIFF
--- a/NHL-Scores.py
+++ b/NHL-Scores.py
@@ -1,4 +1,5 @@
-# All credit to @jtf323 for the original script which I have changed.
+# Author: @jtf323
+# Contributor: @stvhwrd
 
 import json
 import os
@@ -9,7 +10,7 @@ import datetime
 import requests
 from colorama import init, Fore, Back, Style
 
-refresh_time = 60  # Refresh time (Seconds)
+refresh_time = 60  # Refresh time (seconds), as per NHL API
 api_url = 'http://live.nhle.com/GameData/RegularSeasonScoreboardv3.jsonp?loadScoreboard=jQuery110105207217424176633_1428694268811&_=1428694268812'
 api_headers = {'Host': 'live.nhle.com', 'User-Agent': 'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36', 'Referer': 'http://www.nhl.com/ice/scores.htm'}
 
@@ -38,30 +39,40 @@ def main():
             if key == 'games':
                 for game_info in data[key]:
                     gameID = game_info['id']
-                    gameClock = game_info['ts']
+                    game_clock = game_info['ts']
                     status = game_info['bs']
 
-                    away_team_name = game_info['atn']
+                    away_team_locale = game_info['atn']
+                    away_team_name = game_info['atv'].title()
                     away_team_score = game_info['ats']
 
-                    home_team_name = game_info['htn']
+                    home_team_locale = game_info['htn']
+                    home_team_name = game_info['htv'].title()
                     home_team_score = game_info['hts']
 
+                    # NHL API forces team name in locale for both New York teams, i.e. locale + name == "NY Islanders Ny Islanders"
+                    if 'NY ' in home_team_locale:
+                        home_team_locale = 'New York'
+                    if 'NY ' in away_team_locale:
+                        away_team_locale = 'New York'
+
                     # Only show games that are scheduled for today or still in progress
-                    if gameClock.lower() == today.lower() or status == 'LIVE':
-                        header_text = away_team_name + ' @ ' + home_team_name
+                    if game_clock.lower() == today.lower() or status == 'LIVE':
+                        header_text = away_team_locale + ' ' + away_team_name + ' @ ' + home_team_locale + ' ' + home_team_name
                         
                         # Check if the game is over, hasn't started yet, or is still in progress
                         if 'FINAL' in status:
-                            header_text += ' (' + status + ')'    # example (FINAL OT)                        
-                        elif 'DAY' in gameClock:
-                            header_text += ' (' + gameClock + ', ' + status + ' EST)'
+                            header_text += '\n(' + status + ')'    # example (FINAL OT)                        
+                        elif 'DAY' in game_clock:
+                            header_text += '\n(' + game_clock + ', ' + status + ' EST)' # example (TUESDAY 4/21, 7:00 PM EST)
+                        elif game_info['tsc'] == 'critical':
+                            header_text += Fore.RED + '\n(' + game_clock + ' period)' + Fore.RESET    # example output: (10:34 3rd period)
                         else:
-                            header_text += ' (' + gameClock + ' period)'     # example output: (10:34 3rd period)
+                            header_text += '\n(' + game_clock + ' period)'     # example (10:34 3rd period)
 
                         print header_text
 
-                        #highlight the winner green, loser red
+                        #highlight the winner = green, loser = red, still playing = yellow
                         if game_info['atc'] == 'winner':
                             print Fore.GREEN + away_team_name + ': ' + away_team_score + Fore.RESET
                             print Fore.RED + home_team_name + ': ' + home_team_score + Fore.RESET 

--- a/NHL-Scores.py
+++ b/NHL-Scores.py
@@ -1,5 +1,4 @@
-# Author: @jtf323
-# Contributor: @stvhwrd
+# All credit to @jtf323 for the original script which I have changed.
 
 import json
 import os
@@ -57,22 +56,26 @@ def main():
                         away_team_locale = 'New York'
 
                     # Only show games that are scheduled for today or still in progress
-                    if game_clock.lower() == today.lower() or status == 'LIVE':
+                    if game_clock=='TODAY' or game_clock.lower() == today.lower() or status == 'LIVE':
                         header_text = away_team_locale + ' ' + away_team_name + ' @ ' + home_team_locale + ' ' + home_team_name
                         
-                        # Check if the game is over, hasn't started yet, or is still in progress
-                        if 'FINAL' in status:
-                            header_text += '\n(' + status + ')'    # example (FINAL OT)                        
-                        elif 'DAY' in game_clock:
-                            header_text += '\n(' + game_clock + ', ' + status + ' EST)' # example (TUESDAY 4/21, 7:00 PM EST)
-                        elif game_info['tsc'] == 'critical':
-                            header_text += Fore.RED + '\n(' + game_clock + ' period)' + Fore.RESET    # example output: (10:34 3rd period)
+                        # Different displays for a game that is over, hasn't started yet, or is still in progress
+
+                        if 'FINAL' in status:   # example (FINAL OT) 
+                            header_text += '\n(' + status + ')'                           
+                        
+                        elif 'DAY' in game_clock:   # example (TUESDAY 4/21, 7:00 PM EST)
+                            header_text += '\n(' + game_clock + ', ' + status + ' EST)'
+                        
+                        elif game_info['tsc'] == 'critical':    # example output: (1:59 3rd period) in RED
+                            header_text += Fore.RED + '\n(' + game_clock + ' period)' + Fore.RESET
+                        
                         else:
                             header_text += '\n(' + game_clock + ' period)'     # example (10:34 3rd period)
 
                         print header_text
 
-                        #highlight the winner = green, loser = red, still playing = yellow
+                        # highlight the winner = green, loser = red, still playing = yellow
                         if game_info['atc'] == 'winner':
                             print Fore.GREEN + away_team_name + ': ' + away_team_score + Fore.RESET
                             print Fore.RED + home_team_name + ': ' + home_team_score + Fore.RESET 
@@ -85,9 +88,8 @@ def main():
                             print Fore.YELLOW + away_team_name + ': ' + away_team_score + Fore.RESET 
                             print Fore.YELLOW + home_team_name + ': ' + home_team_score + Fore.RESET                               
                         
-                        print ''
-                        print ''
-
+                        print '\n'
+                    
         # Perform the sleep
         time.sleep(refresh_time)
 


### PR DESCRIPTION
* include club names in header and scoreline , instead of "Vancouver @ Calgary" we have "Vancouver Canucks @ Calgary Flames"

* Score displays club names, i.e. "Blackhawks: " instead of "Chicago: "

* To implement club names in scoreline, had to strip out the
redundancies for both New York teams.  NHL stores NY Rangers as location = "NY Rangers" and team: "rangers"

* Game clock displays red when there are fewer than 5 minutes remaining
in the 3rd period.