### PR TITLE
Live edits and simplified colours

### DIFF
--- a/NHL-Scores.py
+++ b/NHL-Scores.py
@@ -106,12 +106,16 @@ def main():
                         # upcoming game
                         elif 'DAY' in game_clock:       # example (TUESDAY 4/21, 7:00 PM EST)
                             header_text += '\n(' + game_clock + ', ' + status + ' EST)'
-
+                        
+                        # pre game
+                        elif 'PRE GAME' in game_clock:       # example (PRE GAME)
+                            header_text += '\n(' + game_clock + ')'
+                        
                         # last 5 minutes of game
                         elif 'critical' in game_stage:  # example output: (1:59 3rd PERIOD) **in RED**
                             header_text += '\n(' + Fore.RED +  game_clock  + ' PERIOD'+ Fore.RESET + ')'
                         
-                        # game underway
+                        # any other time in game
                         else:                           # example (10:34 1st PERIOD)
                             header_text += '\n(' + game_clock + ' PERIOD)'
 

--- a/NHL-Scores.py
+++ b/NHL-Scores.py
@@ -135,7 +135,7 @@ def main():
                             print Fore.RED + home_team_name + ': ' + home_team_score + Fore.RESET
 
                         # Game still underway
-                        elif ('progress' or 'critical') in game_info['tsc']:
+                        elif 'progress' in game_stage or 'critical' in game_stage:
                             print Fore.GREEN + away_team_name + ': ' + away_team_score
                             print home_team_name + ': ' + home_team_score + Fore.RESET
 

--- a/NHL-Scores.py
+++ b/NHL-Scores.py
@@ -17,29 +17,40 @@ api_headers = {'Host': 'live.nhle.com', 'User-Agent': 'Mozilla/5.0 (Windows NT 6
 
 def main():
     clear_screen()
-    now = datetime.datetime.now()
-    today = "" + time.strftime("%A") + " " + "%s/%s" % (now.month, now.day)
+
+# Format dates to match NHL API style:
+
+    # Today's date
+    t = datetime.datetime.now()
+    today = "" + t.strftime("%A") + " " + "%s/%s" % (t.month, t.day)
+    
+    # Yesterday's date
+    y = t - datetime.timedelta(days=1)
+    yesterday = "" + y.strftime("%A") + " " + "%s/%s" % (y.month, y.day)
+
 
     while True:
         clear_screen()
 
         r = requests.get(api_url, headers=api_headers)
         
-        # We get back json data with some JS around it, gotta remove the JS
+    # We get back json data with some JS around it, gotta remove the JS
         json_data = r.text
 
-        # Remove the leading JS
+    # Remove the leading JS
         json_data = json_data.replace('loadScoreboard(', '')
 
-        # Remove the trailing ')'
+    # Remove the trailing ')'
         json_data = json_data[:-1]
 
         data = json.loads(json_data)
         for key in data:
             if key == 'games':
                 for game_info in data[key]:
-                    gameID = game_info['id']
+
+                # Assign more meaningful names    
                     game_clock = game_info['ts']
+                    game_stage = game_info['tsc']
                     status = game_info['bs']
 
                     away_team_locale = game_info['atn']
@@ -50,48 +61,86 @@ def main():
                     home_team_name = game_info['htv'].title()
                     home_team_score = game_info['hts']
 
-                    # NHL API forces team name in locale for both New York teams, i.e. locale + name == "NY Islanders Ny Islanders"
+                # NHL API forces team name in locale for both New York teams, i.e. locale + name == "NY Islanders islanders"
                     if 'NY ' in home_team_locale:
                         home_team_locale = 'New York'
                     if 'NY ' in away_team_locale:
                         away_team_locale = 'New York'
 
-                    # Only show games that are scheduled for today or still in progress
-                    if game_clock=='TODAY' or game_clock.lower() == today.lower() or status == 'LIVE':
+                # NHL API refers to Detroit's team as "redwings" (one word)
+                    if 'wings' in away_team_name:
+                        away_team_name = 'Red Wings'
+                    if 'wings' in home_team_name:
+                        home_team_name = 'Red Wings'
+
+                # NHL API refers to Columbus' team as "bluejackets" (one word)
+                    if 'jackets' in away_team_name:
+                        away_team_name = 'Blue Jackets'
+                    if 'jackets' in home_team_name:
+                        home_team_name = 'Blue Jackets'
+
+                # NHL API refers to Toronto's team as "mapleleafs" (one word)
+                    if 'leafs' in away_team_name:
+                        away_team_name = 'Maple Leafs'
+                    if 'leafs' in home_team_name:
+                        home_team_name = 'Maple Leafs'
+
+                # Show games from today AND yesterday
+                    if (yesterday or today) in game_clock.title() or 'TODAY' in game_clock or 'LIVE' in status:
+                
+                #--- OR if you'd rather see only scores from today ---#
+                
+                # Only show games from today
+                    #if (today or 'Today') in game_clock.title() or 'LIVE' in status:
                         header_text = away_team_locale + ' ' + away_team_name + ' @ ' + home_team_locale + ' ' + home_team_name
                         
-                        # Different displays for a game that is over, hasn't started yet, or is still in progress
 
-                        if 'FINAL' in status:   # example (FINAL OT) 
+                    # Different displays:
+                        
+                        # finished game
+                        if 'FINAL' in status:           # example (FINAL OT) 
                             header_text += '\n(' + status + ')'                           
                         
-                        elif 'DAY' in game_clock:   # example (TUESDAY 4/21, 7:00 PM EST)
+                        # upcoming game
+                        elif 'DAY' in game_clock:       # example (TUESDAY 4/21, 7:00 PM EST)
                             header_text += '\n(' + game_clock + ', ' + status + ' EST)'
+
+                        # last 5 minutes of game
+                        elif 'critical' in game_stage:  # example output: (1:59 3rd PERIOD) **in RED**
+                            header_text += Fore.RED + '\n(' + game_clock + ' PERIOD)' + Fore.RESET
                         
-                        elif game_info['tsc'] == 'critical':    # example output: (1:59 3rd period) in RED
-                            header_text += Fore.RED + '\n(' + game_clock + ' period)' + Fore.RESET
-                        
-                        else:
-                            header_text += '\n(' + game_clock + ' period)'     # example (10:34 3rd period)
+                        # game underway
+                        else:                           # example (10:34 1st PERIOD)
+                            header_text += '\n(' + game_clock + ' PERIOD)'
 
                         print header_text
 
-                        # highlight the winner = green, loser = red, still playing = yellow
+
+                    # Highlight the winner of finished games in red, and games underway in green:
+
+                        # Away team wins
                         if game_info['atc'] == 'winner':
-                            print Fore.GREEN + away_team_name + ': ' + away_team_score + Fore.RESET
-                            print Fore.RED + home_team_name + ': ' + home_team_score + Fore.RESET 
+                            print Fore.RED + away_team_name + ': ' + away_team_score + Fore.RESET
+                            print home_team_name + ': ' + home_team_score
                         
+                        # Home team wins
                         elif game_info['htc'] == 'winner':
-                            print Fore.RED + away_team_name + ': ' + away_team_score + Fore.RESET 
-                            print Fore.GREEN + home_team_name + ': ' + home_team_score + Fore.RESET
-                        
+                            print away_team_name + ': ' + away_team_score
+                            print Fore.RED + home_team_name + ': ' + home_team_score + Fore.RESET
+
+                        # Game still underway
+                        elif ('progress' or 'critical') in game_info['tsc']:
+                            print Fore.GREEN + away_team_name + ': ' + away_team_score
+                            print home_team_name + ': ' + home_team_score + Fore.RESET
+
+                        # Game hasn't yet started
                         else:
-                            print Fore.YELLOW + away_team_name + ': ' + away_team_score + Fore.RESET 
-                            print Fore.YELLOW + home_team_name + ': ' + home_team_score + Fore.RESET                               
-                        
-                        print '\n'
+                            print away_team_name + ': ' + away_team_score
+                            print home_team_name + ': ' + home_team_score                              
+
+                        print ''
                     
-        # Perform the sleep
+    # Perform the sleep
         time.sleep(refresh_time)
 
 

--- a/NHL-Scores.py
+++ b/NHL-Scores.py
@@ -22,11 +22,11 @@ def main():
 
     # Today's date
     t = datetime.datetime.now()
-    today = "" + t.strftime("%A") + " " + "%s/%s" % (t.month, t.day)
+    todays_date = "" + t.strftime("%A") + " " + "%s/%s" % (t.month, t.day)
     
     # Yesterday's date
     y = t - datetime.timedelta(days=1)
-    yesterday = "" + y.strftime("%A") + " " + "%s/%s" % (y.month, y.day)
+    yesterdays_date = "" + y.strftime("%A") + " " + "%s/%s" % (y.month, y.day)
 
 
     while True:
@@ -85,13 +85,15 @@ def main():
                     if 'leafs' in home_team_name:
                         home_team_name = 'Maple Leafs'
 
+
                 # Show games from today AND yesterday
-                    if (yesterday or today) in game_clock.title() or 'TODAY' in game_clock or 'LIVE' in status:
+                    if yesterdays_date in game_clock.title() or todays_date in game_clock.title() or 'TODAY' in game_clock or 'LIVE' in status:
                 
                 #--- OR if you'd rather see only scores from today ---#
                 
                 # Only show games from today
-                    #if (today or 'Today') in game_clock.title() or 'LIVE' in status:
+                    #if todays_date in game_clock.title() or 'TODAY' in game_clock or 'LIVE' in status:
+
                         header_text = away_team_locale + ' ' + away_team_name + ' @ ' + home_team_locale + ' ' + home_team_name
                         
 
@@ -107,7 +109,7 @@ def main():
 
                         # last 5 minutes of game
                         elif 'critical' in game_stage:  # example output: (1:59 3rd PERIOD) **in RED**
-                            header_text += Fore.RED + '\n(' + game_clock + ' PERIOD)' + Fore.RESET
+                            header_text += '\n(' + Fore.RED +  game_clock  + ' PERIOD'+ Fore.RESET + ')'
                         
                         # game underway
                         else:                           # example (10:34 1st PERIOD)


### PR DESCRIPTION
* Option to show only today's games or (via #commenting and -#uncommenting lines) both yesterday's and today's games.

* Manually repair parsed team names for teams with two-word names, i.e. "maple leafs"

* Messed around for way too long with colours, settled on a simpler colour scheme.  Red shows winners of past games, green highlights teams currently playing.  Everything else standard theme colour.  Yes - that **is** how you spell colour in Canada.

Went from this:

![screen shot 2015-04-21 at 4 17 48 pm](https://cloud.githubusercontent.com/assets/4117011/7265529/326e77b4-e850-11e4-863d-d29cd3aeac33.png)

To this:

![screen shot 2015-04-21 at 5 35 15 pm](https://cloud.githubusercontent.com/assets/4117011/7265535/4b9be79e-e850-11e4-919c-abd5bcd767b7.png)

* Minor formatting changes to game clock display

* A few cosmetic code changes (indentation, comments etc.)

* Some (very minor) refactoring, trying to be more "Pythonic"  ...fml